### PR TITLE
fix: do not throw on empty resource files

### DIFF
--- a/scripts/util/inline-resources.ts
+++ b/scripts/util/inline-resources.ts
@@ -2,7 +2,7 @@
 /* tslint:disable:no-eval */
 
 import {dirname, join} from 'path';
-import {readFileSync, writeFileSync} from 'fs';
+import {readFileSync, writeFileSync, existsSync} from 'fs';
 import {sync as glob} from 'glob';
 import * as del from 'del';
 
@@ -26,7 +26,7 @@ export function inlineResources(filePath: string, deleteResource: boolean = fals
 function inlineTemplate(fileContent: string, filePath: string, deleteResource: boolean = false) {
   return fileContent.replace(/templateUrl:\s*'([^']+?\.html)'/g, (_match, templateUrl) => {
     const templatePath = join(dirname(filePath), templateUrl);
-    const templateContent = loadResourceFile(templatePath);
+    const templateContent = loadResourceFile(templatePath) || "";
 
     if (deleteResource === true) {
       del.sync(templatePath);
@@ -46,7 +46,7 @@ function inlineStyles(fileContent: string, filePath: string, deleteResource: boo
     const styleContents = styleUrls
       .map(url => join(dirname(filePath), url))
       .map(path => {
-        const styleContent = loadResourceFile(path);
+        const styleContent = loadResourceFile(path) || "";
         if (deleteResource === true) {
           del.sync(path);
         }
@@ -64,7 +64,11 @@ function removeModuleId(fileContent: string) {
 
 /** Loads the specified resource file and drops line-breaks of the content. */
 function loadResourceFile(filePath: string): string {
-  return readFileSync(filePath, 'utf-8')
-    .replace(/([\n\r]\s*)+/gm, ' ')
-    .replace(/"/g, '\\"');
+  
+  if (existsSync(filePath))
+      return readFileSync(filePath, 'utf-8')
+        .replace(/([\n\r]\s*)+/gm, ' ')
+        .replace(/"/g, '\\"');
+    else
+      return null;
 }

--- a/scripts/util/metadata-inlining.ts
+++ b/scripts/util/metadata-inlining.ts
@@ -1,5 +1,5 @@
 // taken from https://github.com/angular/material2/blob/master/tools/gulp/packaging/metadata-inlining.ts
-import {readFileSync, writeFileSync} from 'fs';
+import {readFileSync, writeFileSync, existsSync} from 'fs';
 import {basename} from 'path';
 import {sync as glob} from 'glob';
 import {join} from 'path';
@@ -21,7 +21,9 @@ export function inlineMetadataResources(metadata: any, componentResources: Map<s
     metadata.styles = [];
     for (const styleUrl of metadata.styleUrls) {
       const fullResourcePath = componentResources.get(basename(styleUrl));
-      metadata.styles.push(readFileSync(fullResourcePath, 'utf-8'));
+      
+      if ( fullResourcePath && existsSync(fullResourcePath))
+        metadata.styles.push(readFileSync(fullResourcePath, 'utf-8'));
     }
     delete metadata.styleUrls;
   }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

If a component references an empty resource file (styleUrls) `npm run lib:build`  throws an error while inlining.

* **What is the current behavior?** (You can also link to an open issue here)

This typically happens when you generate a component with angular-cli like this:

`ng generate component`

The css generated for the component is empty.
angular-cli can handle empty resource files and doesn't throw.

* **What is the new behavior (if this is a feature change)?**

This PR tries to fix the issue.

* **Other information**:
